### PR TITLE
fix: add netlify.toml to pin Ruby version to 4.0.5

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  command = "jekyll build && npm run workbox generateSW workbox-config.js"
+
+[build.environment]
+  RUBY_VERSION = "4.0.5"


### PR DESCRIPTION
## Summary

- Adds `netlify.toml` with `RUBY_VERSION = "4.0.5"` to match `.ruby-version` and `Gemfile`
- Netlify was defaulting to Ruby 3.4.8 via mise, causing `Bundler::GemNotFound` for all Jekyll gems
- Also moves build command from Netlify UI to `netlify.toml` so it is version-controlled

## Test plan

- [ ] Netlify deploy preview builds successfully with Ruby 4.0.5
- [ ] Jekyll builds without gem errors
- [ ] Workbox generates service worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)