### PR TITLE
fix: run bundle install before jekyll build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "jekyll build && npm run workbox generateSW workbox-config.js"
+  command = "bundle install && bundle exec jekyll build && npm run workbox generateSW workbox-config.js"
 
 [build.environment]
   RUBY_VERSION = "4.0.5"


### PR DESCRIPTION
## Summary

- Netlify's gem cache was built under Ruby 3.4.8; switching to 4.0.5 invalidated it
- Explicitly running `bundle install` before `bundle exec jekyll build` forces gem reinstall
- Uses `bundle exec jekyll` (best practice) instead of relying on stale binstubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)