### PR TITLE
feat: sync NODE_VERSION in netlify.toml via Renovate custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,17 @@
       "@benniemosher"
     ]
   },
+  "customManagers": [
+    {
+      "description": "Keep NODE_VERSION in netlify.toml in sync with .node-version",
+      "customType": "regex",
+      "fileMatch": ["netlify\\.toml"],
+      "matchStrings": ["NODE_VERSION = \"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
   "packageRules": [
     {
       "description": "GitHub Actions - automerge patch/minor",


### PR DESCRIPTION
Adds a custom Renovate regex manager so that when Renovate bumps the Node version, it updates both `.node-version` and `NODE_VERSION` in `netlify.toml` in the same PR — no more manual intervention needed.