### PR TITLE
fix: add benniemosher as reviewer on Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
   "assignees": [
     "@benniemosher"
   ],
-  "reviewers": [],
+  "reviewers": ["benniemosher"],
   "vulnerabilityAlerts": {
     "labels": [
       "security",


### PR DESCRIPTION
Sets `reviewers` to `benniemosher` so Renovate PRs show up in the GitHub /pulls/involves feed. The assignees field wasn't working on personal repos due to GitHub App permission scope.